### PR TITLE
Enable system CA certificate trust for corporate networks

### DIFF
--- a/src/ProcessManager.ts
+++ b/src/ProcessManager.ts
@@ -83,7 +83,7 @@ export class ProcessManager {
       ],
       {
         cwd: this.projectDirectory,
-        env: { ...process.env },
+        env: { ...process.env, NODE_USE_SYSTEM_CA: "1" },
         stdio: ["ignore", "pipe", "pipe"],
         detached: false,
       }


### PR DESCRIPTION
## Summary

Enable TLS certificate validation using macOS/system certificate store when spawning the `opencode` server process. This fixes SSL errors for users on corporate networks with custom Certificate Authorities (CAs) or self-signed certificates.

## The Issue

Users on corporate VPNs or networks with TLS inspection (e.g., Cato, Zscaler, corporate proxies) encounter the following error when the plugin attempts to start the opencode server:

```
Error: self signed certificate in certificate chain
```

This happens because:
1. The `opencode` binary is a [Bun](https://bun.sh) application
2. Bun (like Node.js) uses a statically compiled, bundled CA certificate store—it does **not** use the macOS system keychain by default
3. Corporate environments inject custom root CA certificates for TLS inspection, which aren't in Bun's bundled store

## Why This Is Not an Obsidian, opencode, or macOS Issue

### It's not an Obsidian issue
Obsidian correctly spawns child processes. The limitation is that macOS launches GUI applications via [XPC services](https://developer.apple.com/documentation/xpc), which provide a minimal, sanitized environment that doesn't include custom environment variables like `NODE_EXTRA_CA_CERTS`, even if set via `launchctl setenv`.

### It's not an opencode issue
The `opencode` binary works correctly when launched from the terminal (where shell environment variables are available). The Bun runtime respects `NODE_EXTRA_CA_CERTS` and `NODE_USE_SYSTEM_CA` when provided.

### It's not a macOS issue
This is intentional macOS security behavior. XPC services are designed to provide process isolation with a controlled environment. See [Apple Developer Forums discussion](https://developer.apple.com/forums/thread/681550).

## Why Alternative Solutions Don't Work

| Solution | Why It Fails |
|----------|--------------|
| `launchctl setenv NODE_EXTRA_CA_CERTS=...` | XPC-launched apps don't inherit launchctl environment variables ([Stack Overflow](https://stackoverflow.com/questions/25385934/setting-environment-variables-via-launchd-conf-no-longer-works-in-os-x-yosemite)) |
| Adding CA to macOS System Keychain | Bun doesn't use the system keychain by default—it uses its own bundled Mozilla CA store |
| `LSEnvironment` in Obsidian's `Info.plist` | Gets overwritten on every Obsidian update |
| Launching Obsidian from terminal | Works, but poor UX—users expect to click the app icon |

## The Fix

Set `NODE_USE_SYSTEM_CA=1` when spawning the `opencode` process. This environment variable was [introduced in Bun v1.2.23](https://bun.sh/blog/bun-v1.2.23#use-system-s-trusted-certificates-with-use-system-ca) (September 2025):

> Bun can now be configured to use the operating system's trusted root certificates for establishing TLS connections, in addition to the built-in Mozilla CA store. This is useful in corporate environments with custom Certificate Authorities (CAs) or for trusting locally installed self-signed certificates.

With this flag, Bun will include certificates from:
- The macOS System Keychain
- The bundled Mozilla CA store
- Any certificates specified via `NODE_EXTRA_CA_CERTS`

## Possible Side Effects

**None expected.** This flag is additive—it extends the trusted CA store rather than replacing it. Standard public CAs continue to work. The only behavioral change is that certificates in the system keychain are now also trusted.

If a user has explicitly untrusted a certificate in their keychain, that certificate would now be... trusted by Bun. However, this is extremely rare and matches the expected behavior of most applications.

## References

- [Bun v1.2.23 Release Notes - `--use-system-ca`](https://bun.sh/blog/bun-v1.2.23#use-system-s-trusted-certificates-with-use-system-ca)
- [Bun `tls.getCACertificates()` documentation](https://bun.com/reference/node/tls/getCACertificates)
- [Apple: Environment Variables in macOS apps](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPRuntimeConfig/Articles/EnvironmentVars.html)
- [Stack Overflow: launchd.conf no longer works](https://stackoverflow.com/questions/25385934/setting-environment-variables-via-launchd-conf-no-longer-works-in-os-x-yosemite)
- [Node.js does not use macOS keychain](https://github.com/jfromaniello/mac-ca) (same applies to Bun)