### PR TITLE
fix: resolve PATH and health check issues for macOS GUI environment

### DIFF
--- a/src/server/ExecutableResolver.ts
+++ b/src/server/ExecutableResolver.ts
@@ -66,7 +66,7 @@ export class ExecutableResolver {
   /**
    * Get platform-specific directories to search for executables
    */
-  private static getSearchDirectories(): string[] {
+  static getSearchDirectories(): string[] {
     const currentPlatform = platform();
     const homeDir = homedir();
     const searchDirs: string[] = [];

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -1,4 +1,6 @@
 import { ChildProcess, SpawnOptions } from "child_process";
+import { existsSync } from "fs";
+import { dirname } from "path";
 import { EventEmitter } from "events";
 import { OpenCodeSettings } from "../types";
 import { ServerState } from "./types";
@@ -43,9 +45,13 @@ export class ServerManager extends EventEmitter {
     return this.lastError;
   }
 
+  getBaseUrl(): string {
+    return `http://${this.settings.hostname}:${this.settings.port}`;
+  }
+
   getUrl(): string {
-    const encodedPath = btoa(this.projectDirectory);
-    return `http://${this.settings.hostname}:${this.settings.port}/${encodedPath}`;
+    const encodedPath = Buffer.from(this.projectDirectory).toString("base64");
+    return `${this.getBaseUrl()}/${encodedPath}`;
   }
 
   async start(): Promise<boolean> {
@@ -77,16 +83,21 @@ export class ServerManager extends EventEmitter {
     } else {
       // Path mode: resolve executable and verify
       executablePath = ExecutableResolver.resolve(this.settings.opencodePath);
-      
+
       // Pre-flight check: verify executable exists (only for path mode)
       const commandError = await this.processImpl.verifyCommand(executablePath);
       if (commandError) {
         return this.setError(commandError);
       }
-      
+
+      // Build enhanced PATH: macOS/Linux GUI apps (Electron) inherit a minimal
+      // PATH that doesn't include Homebrew, nvm, bun, etc.  The opencode script
+      // uses #!/usr/bin/env node, so node must be discoverable via PATH.
+      const enhancedPath = this.buildEnhancedPath(executablePath);
+
       spawnOptions = {
         cwd: this.projectDirectory,
-        env: { ...process.env, NODE_USE_SYSTEM_CA: "1" },
+        env: { ...process.env, NODE_USE_SYSTEM_CA: "1", PATH: enhancedPath },
         stdio: ["ignore", "pipe", "pipe"],
       };
     }
@@ -224,11 +235,13 @@ export class ServerManager extends EventEmitter {
 
   private async checkServerHealth(): Promise<boolean> {
     try {
-      const response = await fetch(`${this.getUrl()}/global/health`, {
+      const response = await fetch(`${this.getBaseUrl()}/global/health`, {
         method: "GET",
         signal: AbortSignal.timeout(2000),
       });
-      return response.ok;
+      if (!response.ok) return false;
+      const data = await response.json();
+      return data?.healthy === true;
     } catch {
       return false;
     }
@@ -255,5 +268,35 @@ export class ServerManager extends EventEmitter {
 
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Build an enhanced PATH for child processes.
+   * macOS/Linux GUI apps (like Obsidian via Electron) inherit a minimal PATH
+   * (e.g. /usr/bin:/bin:/usr/sbin:/sbin) that doesn't include Homebrew, nvm,
+   * bun, etc.  Since the opencode script uses `#!/usr/bin/env node`, the
+   * `node` binary must be discoverable via PATH.
+   */
+  private buildEnhancedPath(resolvedExecutable: string): string {
+    const currentPath = process.env.PATH || "";
+    const extraDirs: string[] = [];
+
+    // Add the directory containing the resolved executable itself
+    try {
+      const binDir = dirname(resolvedExecutable);
+      if (binDir && !currentPath.includes(binDir)) {
+        extraDirs.push(binDir);
+      }
+    } catch { /* ignore */ }
+
+    // Add well-known directories from ExecutableResolver
+    for (const dir of ExecutableResolver.getSearchDirectories()) {
+      if (!currentPath.includes(dir) && existsSync(dir)) {
+        extraDirs.push(dir);
+      }
+    }
+
+    if (extraDirs.length === 0) return currentPath;
+    return [...extraDirs, currentPath].join(":");
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export const DEFAULT_SETTINGS: OpenCodeSettings = {
   autoStart: false,
   opencodePath: "opencode",
   projectDirectory: "",
-  startupTimeout: 15000,
+  startupTimeout: 120000,
   defaultViewLocation: "sidebar",
   injectWorkspaceContext: false,
   maxNotesInContext: 20,


### PR DESCRIPTION
## Summary

- **Fix exit code 127 on macOS**: Obsidian (Electron) inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include Homebrew, nvm, bun, etc. Since the opencode script uses `#!/usr/bin/env node`, spawning it fails because `node` is not found. This PR builds an enhanced PATH by reusing the search directories from `ExecutableResolver`.
- **Fix health check URL**: `checkServerHealth()` was hitting `/{base64path}/global/health` which is caught by the SPA router and returns HTML (not the health JSON). Changed to use `/global/health` directly and validate `data.healthy === true`.
- **Fix `btoa()` crash with non-Latin1 paths** (fixes #28): Replace `btoa()` with `Buffer.from().toString("base64")` to support Chinese/Unicode characters in project paths.
- **Increase default startup timeout** from 15s to 120s: First boot can take 30-60s for DB migration and plugin installation.

Closes #28, closes #29

## Test plan

- [ ] macOS: Open Obsidian, click the OpenCode icon in the ribbon — server should start successfully
- [ ] Verify the server health check works by checking Obsidian dev console for `[OpenCode]` logs
- [ ] Test with a vault path containing Chinese characters (e.g. `~/笔记/`) — should not crash
- [ ] Test with opencode installed via Homebrew (`/opt/homebrew/bin/opencode`)
- [ ] Test with opencode installed via nvm/bun global install

🤖 Generated with [Claude Code](https://claude.com/claude-code)