### PR TITLE
fix: 修复WSL自定义命令模式 + 添加已知问题警告

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # OpenCode plugin for Obsidian
 
+> ⚠️ **已知问题（重要）**
+> 
+> 在 Windows 上使用 WSL 时，**同时在 Obsidian 中启动 OpenCode 和在 WSL 中启动 OpenCode 会导致 OpenCode 数据库损坏**。
+> 
+> **请避免同时运行两个实例！** 如果需要在 WSL 中使用 OpenCode，请先关闭 Obsidian 中的 OpenCode 面板，反之亦然。
+>
+> 本插件已解决 WSL 上的 OpenCode 作为插件嵌入到 Windows 上的 Obsidian 中无法正常使用的问题，但上述并发问题仍需注意。
+
+---
 
 Give your notes AI capability by embedding Opencode [OpenCode](https://opencode.ai) AI assistant directly in Obsidian:
 

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -64,8 +64,11 @@ export class ServerManager extends EventEmitter {
     // Determine execution mode and resolve executable path
     let executablePath: string;
     let spawnOptions: SpawnOptions;
-    
-    if (this.settings.useCustomCommand) {
+    const useCustomCommand =
+      Boolean(this.settings.useCustomCommand) &&
+      this.settings.customCommand.trim().length > 0;
+
+    if (useCustomCommand) {
       // Custom command mode: use custom command directly with shell
       executablePath = this.settings.customCommand;
       spawnOptions = {
@@ -101,7 +104,7 @@ export class ServerManager extends EventEmitter {
     }
 
     console.log("[OpenCode] Starting server:", {
-      mode: this.settings.useCustomCommand ? "custom" : "path",
+      mode: useCustomCommand ? "custom" : "path",
       command: executablePath,
       port: this.settings.port,
       hostname: this.settings.hostname,
@@ -109,7 +112,7 @@ export class ServerManager extends EventEmitter {
       projectDirectory: this.projectDirectory,
     });
 
-    if (this.settings.useCustomCommand) {
+    if (useCustomCommand) {
       // Custom command mode: spawn with shell, no args appended
       this.process = this.processImpl.start(
         executablePath,
@@ -163,8 +166,8 @@ export class ServerManager extends EventEmitter {
       this.process = null;
 
       if (err.code === "ENOENT") {
-        const command = this.settings.useCustomCommand 
-          ? this.settings.customCommand 
+        const command = useCustomCommand
+          ? this.settings.customCommand
           : this.settings.opencodePath;
         this.setError(
           `Executable not found: '${command}'`


### PR DESCRIPTION
## 修复内容

### 1. 代码修复：自定义命令模式判断逻辑

**文件：** 

**问题：** 原代码只检查  设置项，没有验证  是否为空。这导致在 WSL 环境下，即使未配置自定义命令，也可能错误地进入自定义命令模式。

**修复：**
- 修改判断逻辑，同时检查  和  是否为空
- 确保只有在真正配置了自定义命令时才使用自定义命令模式

### 2. 文档更新：添加已知问题警告

**文件：** 

在 README 顶部添加醒目的警告信息：
- 说明在 Windows 上使用 WSL 时，同时在 Obsidian 和 WSL 中启动 OpenCode 会导致数据库损坏
- 提醒用户避免同时运行两个实例

## 已解决的问题

- ✅ 修复 WSL 上的 OpenCode 作为插件嵌入到 Windows 上的 Obsidian 中无法正常使用的问题
- ✅ 添加已知问题警告，帮助用户避免踩坑

## 测试环境

- Windows 11 + WSL2
- Obsidian 1.8.9
- OpenCode 0.3.28