### PR TITLE
fix: WSL custom command mode + add known issue warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # OpenCode plugin for Obsidian
 
+> ⚠️ **已知问题（重要）**
+> 
+> 在 Windows 上使用 WSL 时，**同时在 Obsidian 中启动 OpenCode 和在 WSL 中启动 OpenCode 会导致 OpenCode 数据库损坏**。
+> 
+> **请避免同时运行两个实例！** 如果需要在 WSL 中使用 OpenCode，请先关闭 Obsidian 中的 OpenCode 面板，反之亦然。
+>
+> 本插件已解决 WSL 上的 OpenCode 作为插件嵌入到 Windows 上的 Obsidian 中无法正常使用的问题，但上述并发问题仍需注意。
+
+---
 
 Give your notes AI capability by embedding Opencode [OpenCode](https://opencode.ai) AI assistant directly in Obsidian:
 

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -64,8 +64,11 @@ export class ServerManager extends EventEmitter {
     // Determine execution mode and resolve executable path
     let executablePath: string;
     let spawnOptions: SpawnOptions;
-    
-    if (this.settings.useCustomCommand) {
+    const useCustomCommand =
+      Boolean(this.settings.useCustomCommand) &&
+      this.settings.customCommand.trim().length > 0;
+
+    if (useCustomCommand) {
       // Custom command mode: use custom command directly with shell
       executablePath = this.settings.customCommand;
       spawnOptions = {
@@ -101,7 +104,7 @@ export class ServerManager extends EventEmitter {
     }
 
     console.log("[OpenCode] Starting server:", {
-      mode: this.settings.useCustomCommand ? "custom" : "path",
+      mode: useCustomCommand ? "custom" : "path",
       command: executablePath,
       port: this.settings.port,
       hostname: this.settings.hostname,
@@ -109,7 +112,7 @@ export class ServerManager extends EventEmitter {
       projectDirectory: this.projectDirectory,
     });
 
-    if (this.settings.useCustomCommand) {
+    if (useCustomCommand) {
       // Custom command mode: spawn with shell, no args appended
       this.process = this.processImpl.start(
         executablePath,
@@ -163,8 +166,8 @@ export class ServerManager extends EventEmitter {
       this.process = null;
 
       if (err.code === "ENOENT") {
-        const command = this.settings.useCustomCommand 
-          ? this.settings.customCommand 
+        const command = useCustomCommand
+          ? this.settings.customCommand
           : this.settings.opencodePath;
         this.setError(
           `Executable not found: '${command}'`


### PR DESCRIPTION
## Changes

### 1. Fix: Custom command mode logic

**File:** `src/server/ServerManager.ts`

**Problem:** The original code only checks `useCustomCommand` setting without verifying if `customCommand` is empty. This causes issues in WSL environment where the plugin may incorrectly enter custom command mode even when no custom command is configured.

**Fix:**
- Modified the condition to check both `useCustomCommand` and whether `customCommand` is empty
- Ensures custom command mode is only used when a custom command is actually configured

### 2. Docs: Add known issue warning

**File:** `README.md`

Added a prominent warning at the top of README:
- Warns users about database corruption when running OpenCode in both Obsidian and WSL simultaneously
- Advises users to avoid running two instances at the same time

## Issues Resolved

- Fixed: OpenCode plugin not working properly when embedded in Obsidian on Windows with WSL
- Added: Known issue warning to help users avoid common pitfalls

## Testing Environment

- Windows 11 + WSL2
- Obsidian 1.8.9
- OpenCode 0.3.28