### PR TITLE
Opens last used OpenCode session instead of making a new one 

### DIFF
--- a/src/client/OpenCodeClient.ts
+++ b/src/client/OpenCodeClient.ts
@@ -25,6 +25,14 @@ type OpenCodeMessageWithParts = {
 
 type OpenCodeSession = {
   id?: string;
+  time?: {
+    created?: number;
+    updated?: number;
+  };
+  created?: number;
+  updated?: number;
+  createdAt?: string | number;
+  updatedAt?: string | number;
 };
 
 type OpenCodeResponse<T> = T | { data?: T } | { message?: T } | null;
@@ -100,6 +108,25 @@ export class OpenCodeClient {
     });
     const session = this.unwrap(result);
     return session?.id ?? null;
+  }
+
+  async getLatestSessionId(): Promise<string | null> {
+    const result = await this.request<OpenCodeSession[]>(
+      "GET",
+      `/session?directory=${encodeURIComponent(this.projectDirectory)}`
+    );
+    const sessions = this.unwrap(result);
+    if (!Array.isArray(sessions) || sessions.length === 0) {
+      return null;
+    }
+
+    const latestSession = sessions.reduce((latest, session) => {
+      return this.getSessionTimestamp(session) > this.getSessionTimestamp(latest)
+        ? session
+        : latest;
+    });
+
+    return latestSession.id ?? null;
   }
 
   async updateContext(params: {
@@ -227,6 +254,28 @@ export class OpenCodeClient {
       }
     }
     return result as T;
+  }
+
+  private getSessionTimestamp(session: OpenCodeSession): number {
+    return Math.max(
+      this.toTimestamp(session.time?.updated),
+      this.toTimestamp(session.updated),
+      this.toTimestamp(session.updatedAt),
+      this.toTimestamp(session.time?.created),
+      this.toTimestamp(session.created),
+      this.toTimestamp(session.createdAt)
+    );
+  }
+
+  private toTimestamp(value: string | number | undefined): number {
+    if (typeof value === "number") {
+      return value;
+    }
+    if (typeof value === "string") {
+      const timestamp = Date.parse(value);
+      return Number.isNaN(timestamp) ? 0 : timestamp;
+    }
+    return 0;
   }
 
   private normalizeBaseUrl(baseUrl: string): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ export default class OpenCodePlugin extends Plugin {
     registerOpenCodeIcons();
 
     await this.loadSettings();
+    this.cachedIframeUrl = this.settings.lastSessionUrl || null;
 
     // Attempt autodetect if opencodePath is empty and not using custom command
     await this.attemptAutodetect();
@@ -60,9 +61,7 @@ export default class OpenCodePlugin extends Plugin {
       client: this.openCodeClient,
       getServerState: () => this.getServerState(),
       getCachedIframeUrl: () => this.cachedIframeUrl,
-      setCachedIframeUrl: (url) => {
-        this.cachedIframeUrl = url;
-      },
+      setCachedIframeUrl: (url) => this.setCachedIframeUrl(url),
       registerEvent: (ref) => this.registerEvent(ref),
     });
 
@@ -72,9 +71,7 @@ export default class OpenCodePlugin extends Plugin {
       client: this.openCodeClient,
       contextManager: this.contextManager,
       getCachedIframeUrl: () => this.cachedIframeUrl,
-      setCachedIframeUrl: (url) => {
-        this.cachedIframeUrl = url;
-      },
+      setCachedIframeUrl: (url) => this.setCachedIframeUrl(url),
       getServerState: () => this.getServerState(),
     });
 
@@ -237,6 +234,11 @@ export default class OpenCodePlugin extends Plugin {
 
   setCachedIframeUrl(url: string | null): void {
     this.cachedIframeUrl = url;
+    const lastSessionUrl = url ?? "";
+    if (this.settings.lastSessionUrl !== lastSessionUrl) {
+      this.settings.lastSessionUrl = lastSessionUrl;
+      void this.saveData(this.settings);
+    }
   }
 
   onServerStateChange(callback: (state: ServerState) => void): () => void {
@@ -262,7 +264,7 @@ export default class OpenCodePlugin extends Plugin {
     this.openCodeClient.updateBaseUrl(nextApiBaseUrl, nextUiBaseUrl, projectDirectory);
 
     if (this.lastBaseUrl && this.lastBaseUrl !== nextUiBaseUrl) {
-      this.cachedIframeUrl = null;
+      this.setCachedIframeUrl(null);
     }
 
     this.lastBaseUrl = nextUiBaseUrl;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface OpenCodeSettings {
   maxSelectionLength: number;
   customCommand: string;
   useCustomCommand: boolean;
+  lastSessionUrl: string;
 }
 
 export const DEFAULT_SETTINGS: OpenCodeSettings = {
@@ -28,6 +29,7 @@ export const DEFAULT_SETTINGS: OpenCodeSettings = {
   maxSelectionLength: 2000,
   customCommand: "",
   useCustomCommand: false,
+  lastSessionUrl: "",
 };
 
 export const OPENCODE_VIEW_TYPE = "opencode-view";

--- a/src/ui/ViewManager.ts
+++ b/src/ui/ViewManager.ts
@@ -97,6 +97,14 @@ export class ViewManager {
       return;
     }
 
+    const latestSessionId = await this.client.getLatestSessionId();
+    if (latestSessionId) {
+      const latestSessionUrl = this.client.getSessionUrl(latestSessionId);
+      this.setCachedIframeUrl(latestSessionUrl);
+      view.setIframeUrl(latestSessionUrl);
+      return;
+    }
+
     const cachedUrl = this.getCachedIframeUrl();
     const existingUrl = cachedUrl ?? view.getIframeUrl();
     if (existingUrl && this.client.resolveSessionId(existingUrl)) {


### PR DESCRIPTION

- Added lastSessionUrl to settings to persist the session between plugin reloads.

- Implemented getLatestSessionId in OpenCodeClient to fetch existing sessions from the server.

- Updated ViewManager to prioritize the most recently updated session from the server before falling back to the cached URL or creating a new session.

- Ensured the session cache is cleared if the server base URL (port/hostname) changes.