### PR TITLE
fix: bypass CORS for health check and API calls

### DIFF
--- a/src/client/OpenCodeClient.ts
+++ b/src/client/OpenCodeClient.ts
@@ -64,12 +64,30 @@ export class OpenCodeClient {
 
   async initializeProject(): Promise<boolean> {
     try {
+      const http = require("http");
       const url = `${this.apiBaseUrl}/session?directory=${encodeURIComponent(this.projectDirectory)}`;
-      const response = await fetch(url, {
-        method: "GET",
-        headers: {
-          "x-opencode-directory": this.projectDirectory,
-        },
+      const urlObj = new URL(url);
+      const response = await new Promise<{ ok: boolean; status: number }>((resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: urlObj.hostname,
+            port: urlObj.port,
+            path: urlObj.pathname + urlObj.search,
+            method: "GET",
+            headers: {
+              "x-opencode-directory": this.projectDirectory,
+            },
+          },
+          (res) => {
+            res.resume(); // drain response
+            resolve({
+              ok: (res.statusCode ?? 500) >= 200 && (res.statusCode ?? 500) < 300,
+              status: res.statusCode ?? 500,
+            });
+          }
+        );
+        req.on("error", reject);
+        req.end();
       });
 
       if (response.ok) {
@@ -186,13 +204,39 @@ export class OpenCodeClient {
   private async request<T>(method: string, path: string, body?: unknown): Promise<OpenCodeResponse<T>> {
     try {
       const url = `${this.apiBaseUrl}${path}`;
-      const response = await fetch(url, {
+      const urlObj = new URL(url);
+      const http = require("http");
+      const options = {
+        hostname: urlObj.hostname,
+        port: urlObj.port,
+        path: urlObj.pathname,
         method,
         headers: {
           "Content-Type": "application/json",
           "x-opencode-directory": this.projectDirectory,
         },
-        body: body ? JSON.stringify(body) : undefined,
+      };
+      const response = await new Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>((resolve, reject) => {
+        const req = http.request(options, (res) => {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => {
+            resolve({
+              ok: (res.statusCode ?? 500) >= 200 && (res.statusCode ?? 500) < 300,
+              status: res.statusCode ?? 500,
+              json: async () => {
+                try {
+                  return JSON.parse(data || "null");
+                } catch {
+                  return null;
+                }
+              },
+            });
+          });
+        });
+        req.on("error", reject);
+        if (body) req.write(JSON.stringify(body));
+        req.end();
       });
 
       if (!response.ok) {
@@ -203,9 +247,7 @@ export class OpenCodeClient {
         return null;
       }
 
-      const json = await response
-        .json()
-        .catch(() => null);
+      const json = await response.json();
       return json as OpenCodeResponse<T>;
     } catch (error) {
       console.error("[OpenCode] API request error", error);

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -230,7 +230,19 @@ export class ServerManager extends EventEmitter {
       });
       return response.ok;
     } catch {
-      return false;
+      // CORS blocked the request. Fallback: send request in no-cors mode.
+      // The response is opaque (can't read status), but if the request
+      // reaches the server we know it's alive. Rejects on network error.
+      try {
+        await fetch(`${this.getUrl()}/global/health`, {
+          method: "GET",
+          mode: "no-cors",
+          signal: AbortSignal.timeout(2000),
+        });
+        return true;
+      } catch {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
- checkServerHealth: fallback to no-cors fetch when CORS blocks normal fetch
- request / initializeProject: use Node.js http.request instead of fetch to bypass browser CORS entirely

This allows the plugin to attach to an externally-managed opencode server that was started without --cors app://obsidian.md.