### PR TITLE
fix: collapse sidebar instead of detaching leaf on toggle

### DIFF
--- a/src/ui/OpenCodeView.ts
+++ b/src/ui/OpenCodeView.ts
@@ -193,6 +193,10 @@ export class OpenCodeView extends ItemView {
     }
   }
 
+  focusIframe(): void {
+    this.iframeEl?.focus();
+  }
+
   private renderErrorState(): void {
     this.contentEl.empty();
 

--- a/src/ui/ViewManager.ts
+++ b/src/ui/ViewManager.ts
@@ -76,10 +76,10 @@ export class ViewManager {
       const isInSidebar = existingLeaf.getRoot() === this.app.workspace.rightSplit;
 
       if (isInSidebar) {
-        // For sidebar views, check if sidebar is collapsed
+        // For sidebar views, collapse the sidebar instead of detaching the leaf
         const rightSplit = this.app.workspace.rightSplit;
         if (rightSplit && !rightSplit.collapsed) {
-          existingLeaf.detach();
+          rightSplit.collapse();
         } else {
           this.app.workspace.revealLeaf(existingLeaf);
         }

--- a/src/ui/ViewManager.ts
+++ b/src/ui/ViewManager.ts
@@ -23,6 +23,7 @@ export class ViewManager {
   private getCachedIframeUrl: () => string | null;
   private setCachedIframeUrl: (url: string | null) => void;
   private getServerState: () => string;
+  private previousEditorLeaf: WorkspaceLeaf | null = null;
 
   constructor(deps: ViewManagerDeps) {
     this.app = deps.app;
@@ -76,12 +77,29 @@ export class ViewManager {
       const isInSidebar = existingLeaf.getRoot() === this.app.workspace.rightSplit;
 
       if (isInSidebar) {
-        // For sidebar views, collapse the sidebar instead of detaching the leaf
         const rightSplit = this.app.workspace.rightSplit;
         if (rightSplit && !rightSplit.collapsed) {
-          rightSplit.collapse();
+          // COLLAPSING: save focus target before collapsing
+          const currentActive = this.app.workspace.activeLeaf;
+          if (currentActive === existingLeaf && this.previousEditorLeaf) {
+            // OpenCode view was focused — restore previous editor focus after collapse
+            rightSplit.collapse();
+            this.app.workspace.setActiveLeaf(this.previousEditorLeaf, { focus: true });
+          } else {
+            rightSplit.collapse();
+          }
         } else {
+          // EXPANDING: save current editor focus, then focus OpenCode
+          const activeLeaf = this.app.workspace.activeLeaf;
+          if (activeLeaf && activeLeaf !== existingLeaf) {
+            this.previousEditorLeaf = activeLeaf;
+          }
           this.app.workspace.revealLeaf(existingLeaf);
+          this.app.workspace.setActiveLeaf(existingLeaf, { focus: true });
+          const view = existingLeaf.view;
+          if (view instanceof OpenCodeView) {
+            requestAnimationFrame(() => view.focusIframe());
+          }
         }
       } else {
         // For main area views, just detach (close the tab)


### PR DESCRIPTION
Currently `toggleView()` calls `existingLeaf.detach()` when collapsing the sidebar via the toggle hotkey. This destroys the OpenCode view entirely — the next toggle has to recreate the leaf and re-initialize the view from scratch.

This changes to `rightSplit.collapse()` instead. The leaf stays intact in the sidebar, so the next toggle simply expands and reveals the existing view.