### PR TITLE
Fix OpenCode process cleanup on Obsidian shutdown

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ export default class OpenCodePlugin extends Plugin {
       await this.saveData(this.settings);
       this.refreshClientState();
       if (this.getServerState() === "running") {
-        await this.stopServer();
+        await this.stopServer(false);
         await this.startServer();
       }
     });
@@ -117,7 +117,7 @@ export default class OpenCodePlugin extends Plugin {
       id: "start-opencode-server",
       name: "Start OpenCode server",
       callback: () => {
-        this.startServer();
+        void this.startServer();
       },
     });
 
@@ -125,7 +125,7 @@ export default class OpenCodePlugin extends Plugin {
       id: "stop-opencode-server",
       name: "Stop OpenCode server",
       callback: () => {
-        this.stopServer();
+        void this.stopServer();
       },
     });
 
@@ -149,7 +149,7 @@ export default class OpenCodePlugin extends Plugin {
 
   async onunload(): Promise<void> {
     this.contextManager.destroy();
-    await this.stopServer();
+    await this.stopServer(false);
     this.app.workspace.detachLeavesOfType(OPENCODE_VIEW_TYPE);
   }
 
@@ -210,9 +210,11 @@ export default class OpenCodePlugin extends Plugin {
     return success;
   }
 
-  async stopServer(): Promise<void> {
+  async stopServer(showNotice = true): Promise<void> {
     await this.processManager.stop();
-    new Notice("OpenCode server stopped");
+    if (showNotice) {
+      new Notice("OpenCode server stopped");
+    }
   }
 
   getServerState(): ServerState {
@@ -294,7 +296,7 @@ export default class OpenCodePlugin extends Plugin {
     this.registerEvent(
       this.app.workspace.on("quit", () => {
         console.log("[OpenCode] Obsidian quitting - performing sync cleanup");
-        this.stopServer();
+        this.processManager.stopSync();
       })
     );
   }

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -210,6 +210,20 @@ export class ServerManager extends EventEmitter {
     await this.processImpl.stop(proc);
   }
 
+  stopSync(): void {
+    if (!this.process) {
+      this.setState("stopped");
+      return;
+    }
+
+    const proc = this.process;
+
+    this.setState("stopped");
+    this.process = null;
+
+    this.processImpl.stopSync(proc);
+  }
+
   private setState(state: ServerState): void {
     this.state = state;
     this.emit("stateChange", state);

--- a/src/server/process/OpenCodeProcess.ts
+++ b/src/server/process/OpenCodeProcess.ts
@@ -13,6 +13,9 @@ export interface OpenCodeProcess {
    *  Handles all PID/process tree logic internally. */
   stop(process: ChildProcess): Promise<void>;
 
+  /** Stop the process synchronously during application shutdown. */
+  stopSync(process: ChildProcess): void;
+
   /** Verify that command exists and is executable. Returns error message or null if OK. */
   verifyCommand(command: string): Promise<string | null>;
 }

--- a/src/server/process/PosixProcess.ts
+++ b/src/server/process/PosixProcess.ts
@@ -44,6 +44,19 @@ export class PosixProcess implements OpenCodeProcess {
     }
   }
 
+  stopSync(proc: ChildProcess): void {
+    const pid = proc.pid;
+    if (!pid) {
+      return;
+    }
+
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // 进程可能已经退出
+    }
+  }
+
   async verifyCommand(command: string): Promise<string | null> {
     // Check if command is absolute path - verify it exists and is executable
     if (command.startsWith('/') || command.startsWith('./')) {

--- a/src/server/process/WindowsProcess.ts
+++ b/src/server/process/WindowsProcess.ts
@@ -33,43 +33,25 @@ export class WindowsProcess implements OpenCodeProcess {
 
     console.log("[OpenCode] Stopping server process tree, PID:", pid);
 
-    // Method 1: Find and kill child processes (actual node.exe) using PowerShell
-    // This is necessary because shell: true spawns cmd.exe -> node.exe, and
-    // killing cmd.exe leaves node.exe orphaned
     try {
-      const { execSync } = require("child_process");
-      const output = execSync(
-        `powershell -Command "Get-CimInstance Win32_Process -Filter \\"ParentProcessId=${pid}\\" | Select-Object ProcessId"`,
-        { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] }
-      );
-
-      const lines = output.split("\n").slice(3); // Skip headers
-      for (const line of lines) {
-        const childPid = line.trim();
-        if (childPid && !isNaN(parseInt(childPid))) {
-          try {
-            execSync(`taskkill /F /PID ${childPid}`, { stdio: "ignore" });
-          } catch {
-            // Child may already be gone
-          }
-        }
-      }
+      await this.execAsync(`taskkill /F /T /PID ${pid}`);
     } catch {
-      // PowerShell lookup failed, continue to other methods
+      // 进程可能已经退出
     }
 
-    // Method 2: Kill the parent process (cmd.exe)
-    try {
-      await this.execAsync(`taskkill /F /PID ${pid}`);
-    } catch {
-      // Parent may already be gone
-    }
-
-    // Clear stored process
     WindowsProcess.currentProcess = null;
+    await this.waitForExit(process, 250);
+  }
 
-    // Wait for process to exit
-    await this.waitForExit(process, 5000);
+  stopSync(process: ChildProcess): void {
+    const pid = process.pid;
+    if (!pid) {
+      WindowsProcess.currentProcess = null;
+      return;
+    }
+
+    WindowsProcess.killProcessSync(pid);
+    WindowsProcess.currentProcess = null;
   }
 
   private static registerCleanupHandler(): void {
@@ -92,37 +74,9 @@ export class WindowsProcess implements OpenCodeProcess {
   private static killProcessSync(pid: number): void {
     try {
       const { execSync } = require("child_process");
-
-      // Method 1: Kill child processes using PowerShell
-      try {
-        const output = execSync(
-          `powershell -Command "Get-CimInstance Win32_Process -Filter \\"ParentProcessId=${pid}\\" | Select-Object ProcessId"`,
-          { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] }
-        );
-
-        const lines = output.split("\n").slice(3);
-        for (const line of lines) {
-          const childPid = line.trim();
-          if (childPid && !isNaN(parseInt(childPid))) {
-            try {
-              execSync(`taskkill /F /PID ${childPid}`, { stdio: "ignore" });
-            } catch {
-              // Child may already be gone
-            }
-          }
-        }
-      } catch {
-        // PowerShell lookup failed
-      }
-
-      // Method 2: Kill parent process
-      try {
-        execSync(`taskkill /F /PID ${pid}`, { stdio: "ignore" });
-      } catch {
-        // Parent may already be gone
-      }
+      execSync(`taskkill /F /T /PID ${pid}`, { stdio: "ignore" });
     } catch {
-      // Process may already be gone
+      // 进程可能已经退出
     }
   }
 


### PR DESCRIPTION
## Summary

This fixes an issue where `opencode serve` can remain running after Obsidian exits, especially on Windows.

The previous Windows cleanup only killed the parent process and direct child processes. Because the plugin starts OpenCode through a shell, the actual `opencode.exe` server process can remain orphaned and keep listening on the configured port.

## Changes

- Use `taskkill /F /T /PID` on Windows to terminate the full process tree.
- Add synchronous shutdown cleanup via `stopSync`.
- Use synchronous cleanup during Obsidian `quit`.
- Avoid showing stop notices during unload/restart cleanup.
- Keep the existing safety boundary: the plugin only stops processes it started and does not kill by port or process name.

## Verification

- Built successfully with:
  - `bun run tsc -noEmit -skipLibCheck --ignoreDeprecations 5.0`
  - `bun run esbuild.config.mjs production`
- Manually verified in Obsidian on Windows:
  - Start OpenCode server from the plugin.
  - Close Obsidian.
  - Confirm the configured port is released and no plugin-started `opencode serve` process remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)